### PR TITLE
fix: 托盘图标切换 + 防止 Ctrl 键卡住

### DIFF
--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -88,10 +88,15 @@ pub fn get_selected_text() -> Result<(ClipboardGuard, Option<String>)> {
     thread::sleep(Duration::from_millis(10));
 
     enigo.key(Key::Control, Direction::Press)?;
-    thread::sleep(Duration::from_millis(10));
-    enigo.key(Key::Unicode('c'), Direction::Click)?;
-    thread::sleep(Duration::from_millis(10));
-    enigo.key(Key::Control, Direction::Release)?;
+    let result = (|| -> Result<()> {
+        thread::sleep(Duration::from_millis(10));
+        enigo.key(Key::Unicode('c'), Direction::Click)?;
+        thread::sleep(Duration::from_millis(10));
+        Ok(())
+    })();
+    // 最大努力保证 Ctrl 不会遗留为按下状态
+    let _ = enigo.key(Key::Control, Direction::Release);
+    result?;
 
     // 5. 等待剪贴板更新（带重试机制）
     //    某些应用（如 Electron 应用、IDE）响应较慢，100ms 可能不够
@@ -192,10 +197,14 @@ pub fn insert_text_with_context(
     // 2. 模拟 Ctrl+V 粘贴
     //    注意：如果有选中内容，粘贴会自动替换；如果没有，会在光标处插入
     enigo.key(Key::Control, Direction::Press)?;
-    thread::sleep(Duration::from_millis(10));
-    enigo.key(Key::Unicode('v'), Direction::Click)?;
-    thread::sleep(Duration::from_millis(10));
-    enigo.key(Key::Control, Direction::Release)?;
+    let result = (|| -> Result<()> {
+        thread::sleep(Duration::from_millis(10));
+        enigo.key(Key::Unicode('v'), Direction::Click)?;
+        thread::sleep(Duration::from_millis(10));
+        Ok(())
+    })();
+    let _ = enigo.key(Key::Control, Direction::Release);
+    result?;
 
     // 3. 等待粘贴完成
     thread::sleep(Duration::from_millis(100));

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -417,6 +417,9 @@ pub struct AppConfig {
     /// 关闭行为: "close" = 直接关闭, "minimize" = 最小化到托盘, None = 每次询问
     #[serde(default)]
     pub close_action: Option<String>,
+    /// 是否在任务栏通知区域显示系统托盘图标
+    #[serde(default = "default_show_tray_icon")]
+    pub show_tray_icon: bool,
     /// 热键配置（旧版，保留以便迁移）
     #[serde(default, skip_serializing)]
     pub hotkey_config: Option<HotkeyConfig>,
@@ -657,6 +660,10 @@ fn default_use_realtime_asr() -> bool {
     true
 }
 
+fn default_show_tray_icon() -> bool {
+    true
+}
+
 impl AppConfig {
     pub fn new() -> Self {
         Self {
@@ -669,6 +676,7 @@ impl AppConfig {
             smart_command_config: SmartCommandConfig::default(),
             assistant_config: AssistantConfig::default(),
             close_action: None,
+            show_tray_icon: default_show_tray_icon(),
             hotkey_config: None,
             dual_hotkey_config: DualHotkeyConfig::default(),
             transcription_mode: TranscriptionMode::default(),

--- a/src-tauri/src/hotkey_service.rs
+++ b/src-tauri/src/hotkey_service.rs
@@ -1,4 +1,5 @@
 // 全局快捷键监听模块 - 单例模式重构 + 双模式支持
+#[cfg(not(target_os = "windows"))]
 use rdev::{listen, Event, EventType, Key};
 use std::sync::{Arc, Mutex, RwLock};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -98,6 +99,42 @@ fn are_keys_physically_down(keys: &[HotkeyKey]) -> bool {
     keys.iter().all(|k| is_key_physically_down(k))
 }
 
+// Windows 下使用轮询（避免低级 hook 导致的按键异常）
+#[cfg(target_os = "windows")]
+const HOTKEY_POLL_INTERVAL_MS: u64 = 10;
+
+/// 严格匹配：要求目标按键全部按下，且没有额外的修饰键被按下
+#[cfg(target_os = "windows")]
+fn is_hotkey_pressed_strict(target_keys: &[HotkeyKey]) -> bool {
+    if target_keys.is_empty() {
+        return false;
+    }
+
+    if !are_keys_physically_down(target_keys) {
+        return false;
+    }
+
+    // 检查是否有“额外修饰键”被按下（用于模拟 rdev 的严格匹配 len==keys.len() 行为）
+    const MODIFIERS: [HotkeyKey; 8] = [
+        HotkeyKey::ControlLeft,
+        HotkeyKey::ControlRight,
+        HotkeyKey::ShiftLeft,
+        HotkeyKey::ShiftRight,
+        HotkeyKey::AltLeft,
+        HotkeyKey::AltRight,
+        HotkeyKey::MetaLeft,
+        HotkeyKey::MetaRight,
+    ];
+
+    for modifier in MODIFIERS.iter() {
+        if is_key_physically_down(modifier) && !target_keys.contains(modifier) {
+            return false;
+        }
+    }
+
+    true
+}
+
 // 看门狗检查间隔（毫秒）
 const WATCHDOG_INTERVAL_MS: u64 = 100;
 // 按键释放后的稳定时间（毫秒）
@@ -156,6 +193,7 @@ impl HotkeyService {
     }
 
     /// 将 rdev::Key 转换为 HotkeyKey
+    #[cfg(not(target_os = "windows"))]
     fn rdev_to_hotkey_key(key: Key) -> Option<HotkeyKey> {
         match key {
             Key::ControlLeft => Some(HotkeyKey::ControlLeft),
@@ -254,7 +292,187 @@ impl HotkeyService {
         thread::spawn(move || {
             tracing::info!("快捷键监听线程已启动");
 
+            // ====================================================================
+            // Windows：使用 GetAsyncKeyState 轮询按键状态，避免低级 hook 的兼容性问题
+            // ====================================================================
+            #[cfg(target_os = "windows")]
+            {
+                tracing::info!(
+                    "Windows 热键监听：启用轮询模式 ({}ms)",
+                    HOTKEY_POLL_INTERVAL_MS
+                );
+
+                let mut prev_dictation_down = false;
+                let mut prev_assistant_down = false;
+                let mut prev_release_down = false;
+
+                loop {
+                    thread::sleep(Duration::from_millis(HOTKEY_POLL_INTERVAL_MS));
+
+                    let dictation_cfg = dictation_config.read().unwrap().clone();
+                    let assistant_cfg = assistant_config.read().unwrap().clone();
+
+                    let dictation_down = is_hotkey_pressed_strict(&dictation_cfg.keys);
+                    let assistant_down = is_hotkey_pressed_strict(&assistant_cfg.keys);
+                    let release_down = dictation_cfg
+                        .release_mode_keys
+                        .as_deref()
+                        .map(is_hotkey_pressed_strict)
+                        .unwrap_or(false);
+
+                    // 未激活时：同步边沿状态，避免激活瞬间误触发
+                    if !is_active.load(Ordering::Relaxed) {
+                        prev_dictation_down = dictation_down;
+                        prev_assistant_down = assistant_down;
+                        prev_release_down = release_down;
+                        continue;
+                    }
+
+                    let dictation_rise = dictation_down && !prev_dictation_down;
+                    let dictation_fall = !dictation_down && prev_dictation_down;
+                    let assistant_rise = assistant_down && !prev_assistant_down;
+                    let assistant_fall = !assistant_down && prev_assistant_down;
+                    let release_rise = release_down && !prev_release_down;
+
+                    // 更新 pressed_keys（仅用于调试信息）
+                    {
+                        let mut s = state.lock().unwrap();
+                        s.pressed_keys.clear();
+
+                        // 只追踪当前配置相关的按键，避免无意义的全键盘扫描
+                        let mut keys_to_check: HashSet<HotkeyKey> = HashSet::new();
+                        for key in dictation_cfg.keys.iter() {
+                            keys_to_check.insert(key.clone());
+                        }
+                        for key in assistant_cfg.keys.iter() {
+                            keys_to_check.insert(key.clone());
+                        }
+                        if let Some(ref keys) = dictation_cfg.release_mode_keys {
+                            for key in keys.iter() {
+                                keys_to_check.insert(key.clone());
+                            }
+                        }
+
+                        for key in keys_to_check.into_iter() {
+                            if is_key_physically_down(&key) {
+                                s.pressed_keys.insert(key);
+                            }
+                        }
+                    }
+
+                    let mut start_action: Option<(TriggerMode, bool)> = None;
+                    let mut stop_action: Option<(TriggerMode, bool)> = None;
+
+                    {
+                        let mut s = state.lock().unwrap();
+
+                        // === 松手模式：再次按下松手模式快捷键则取消录音 ===
+                        if s.is_recording && s.is_release_mode_triggered && release_rise {
+                            tracing::info!("松手模式下再次按下快捷键，取消录音");
+                            s.is_recording = false;
+                            s.watchdog_running = false;
+                            s.current_trigger_mode = None;
+                            s.is_release_mode_triggered = false;
+                            stop_action = Some((TriggerMode::Dictation, true));
+                        } else if !s.is_recording {
+                            // 确定触发模式（优先级：松手模式 > 普通听写 > AI助手）
+                            if release_rise {
+                                tracing::info!("检测到快捷键按下: 听写模式 (松手模式)");
+                                s.is_recording = true;
+                                s.current_trigger_mode = Some(TriggerMode::Dictation);
+                                s.is_release_mode_triggered = true;
+                                s.watchdog_running = false;
+                                start_action = Some((TriggerMode::Dictation, true));
+                            } else if dictation_rise {
+                                let mode_desc = match dictation_cfg.mode {
+                                    crate::config::HotkeyMode::Press => "普通模式",
+                                    crate::config::HotkeyMode::Toggle => "切换模式",
+                                };
+                                tracing::info!("检测到快捷键按下: 听写模式 ({})", mode_desc);
+                                s.is_recording = true;
+                                s.current_trigger_mode = Some(TriggerMode::Dictation);
+                                s.is_release_mode_triggered = false;
+                                s.watchdog_running = false;
+                                start_action = Some((TriggerMode::Dictation, false));
+                            } else if assistant_rise {
+                                let mode_desc = match assistant_cfg.mode {
+                                    crate::config::HotkeyMode::Press => "普通模式",
+                                    crate::config::HotkeyMode::Toggle => "切换模式",
+                                };
+                                tracing::info!("检测到快捷键按下: AI助手模式 ({})", mode_desc);
+                                s.is_recording = true;
+                                s.current_trigger_mode = Some(TriggerMode::AiAssistant);
+                                s.is_release_mode_triggered = false;
+                                s.watchdog_running = false;
+                                start_action = Some((TriggerMode::AiAssistant, false));
+                            }
+                        } else if !s.is_release_mode_triggered {
+                            // 录音中：根据当前触发模式处理停止逻辑（Press=松手停止；Toggle=再次按下停止）
+                            match s.current_trigger_mode {
+                                Some(TriggerMode::Dictation) => match dictation_cfg.mode {
+                                    crate::config::HotkeyMode::Press => {
+                                        if dictation_fall {
+                                            tracing::info!("检测到快捷键释放，停止录音");
+                                            s.is_recording = false;
+                                            s.watchdog_running = false;
+                                            s.current_trigger_mode = None;
+                                            stop_action = Some((TriggerMode::Dictation, false));
+                                        }
+                                    }
+                                    crate::config::HotkeyMode::Toggle => {
+                                        if dictation_rise {
+                                            tracing::info!("检测到快捷键再次按下，停止录音（切换模式）");
+                                            s.is_recording = false;
+                                            s.watchdog_running = false;
+                                            s.current_trigger_mode = None;
+                                            stop_action = Some((TriggerMode::Dictation, false));
+                                        }
+                                    }
+                                },
+                                Some(TriggerMode::AiAssistant) => match assistant_cfg.mode {
+                                    crate::config::HotkeyMode::Press => {
+                                        if assistant_fall {
+                                            tracing::info!("检测到快捷键释放，停止录音");
+                                            s.is_recording = false;
+                                            s.watchdog_running = false;
+                                            s.current_trigger_mode = None;
+                                            stop_action = Some((TriggerMode::AiAssistant, false));
+                                        }
+                                    }
+                                    crate::config::HotkeyMode::Toggle => {
+                                        if assistant_rise {
+                                            tracing::info!("检测到快捷键再次按下，停止录音（切换模式）");
+                                            s.is_recording = false;
+                                            s.watchdog_running = false;
+                                            s.current_trigger_mode = None;
+                                            stop_action = Some((TriggerMode::AiAssistant, false));
+                                        }
+                                    }
+                                },
+                                None => {}
+                            }
+                        }
+                    }
+
+                    if let Some((mode, is_release_mode)) = start_action {
+                        if let Some(cb) = on_start.read().unwrap().as_ref() {
+                            cb(mode, is_release_mode);
+                        }
+                    }
+                    if let Some((mode, is_release_mode)) = stop_action {
+                        if let Some(cb) = on_stop.read().unwrap().as_ref() {
+                            cb(mode, is_release_mode);
+                        }
+                    }
+
+                    prev_dictation_down = dictation_down;
+                    prev_assistant_down = assistant_down;
+                    prev_release_down = release_down;
+                }
+            }
+
             // 外层循环：如果 rdev 监听器崩溃则自动重启
+            #[cfg(not(target_os = "windows"))]
             loop {
                 let mut first_key_logged = false;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,7 +31,7 @@ use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{
     AppHandle, Emitter, Manager,
-    tray::{TrayIconBuilder, TrayIconEvent, MouseButton, MouseButtonState},
+    tray::{TrayIcon, TrayIconBuilder, TrayIconEvent, MouseButton, MouseButtonState},
     menu::{Menu, MenuItem},
     WindowEvent,
 };
@@ -117,6 +117,8 @@ struct AppState {
     is_processing_stop: Arc<AtomicBool>,
     /// 录音时静音其他应用的管理器
     audio_mute_manager: Arc<Mutex<Option<AudioMuteManager>>>,
+    /// 系统托盘图标（用于动态显示/隐藏）
+    tray_icon: Arc<Mutex<Option<TrayIcon>>>,
 }
 
 // Tauri Commands
@@ -130,6 +132,7 @@ async fn save_config(
     llm_config: Option<config::LlmConfig>,
     smart_command_config: Option<config::SmartCommandConfig>,
     close_action: Option<String>,
+    show_tray_icon: Option<bool>,
     asr_config: Option<config::AsrConfig>,
     hotkey_config: Option<config::HotkeyConfig>,
     dual_hotkey_config: Option<config::DualHotkeyConfig>,
@@ -138,6 +141,10 @@ async fn save_config(
     dictionary: Option<Vec<String>>,
 ) -> Result<String, String> {
     tracing::info!("保存配置...");
+
+    // 某些前端调用只会提交部分字段（例如仅更新热键/词库），这里用旧配置兜底避免意外清空。
+    let existing = AppConfig::load().unwrap_or_else(|_| AppConfig::new());
+
     let has_fallback = !fallback_api_key.is_empty();
     let config = AppConfig {
         dashscope_api_key: api_key.clone(),
@@ -161,17 +168,18 @@ async fn save_config(
             },
             enable_fallback: has_fallback,
         }),
-        use_realtime_asr: use_realtime.unwrap_or(true),
-        enable_llm_post_process: enable_post_process.unwrap_or(false),
-        llm_config: llm_config.unwrap_or_default(),
-        smart_command_config: smart_command_config.unwrap_or_default(),
-        assistant_config: assistant_config.unwrap_or_default(),
-        close_action,
+        use_realtime_asr: use_realtime.unwrap_or(existing.use_realtime_asr),
+        enable_llm_post_process: enable_post_process.unwrap_or(existing.enable_llm_post_process),
+        llm_config: llm_config.unwrap_or(existing.llm_config),
+        smart_command_config: smart_command_config.unwrap_or(existing.smart_command_config),
+        assistant_config: assistant_config.unwrap_or(existing.assistant_config),
+        close_action: close_action.or(existing.close_action),
+        show_tray_icon: show_tray_icon.unwrap_or(existing.show_tray_icon),
         hotkey_config,
-        dual_hotkey_config: dual_hotkey_config.unwrap_or_default(),
-        transcription_mode: config::TranscriptionMode::default(),
-        enable_mute_other_apps: enable_mute_other_apps.unwrap_or(false),
-        dictionary: dictionary.unwrap_or_default(),
+        dual_hotkey_config: dual_hotkey_config.unwrap_or(existing.dual_hotkey_config),
+        transcription_mode: existing.transcription_mode,
+        enable_mute_other_apps: enable_mute_other_apps.unwrap_or(existing.enable_mute_other_apps),
+        dictionary: dictionary.unwrap_or(existing.dictionary),
     };
 
     config
@@ -1629,6 +1637,20 @@ async fn hide_to_tray(app_handle: AppHandle) -> Result<String, String> {
 }
 
 #[tauri::command]
+async fn set_tray_icon_visible(app_handle: AppHandle, visible: bool) -> Result<(), String> {
+    let state = app_handle.state::<AppState>();
+    let tray = state
+        .tray_icon
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| "托盘图标尚未初始化".to_string())?;
+
+    tray.set_visible(visible).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
 async fn quit_app(app_handle: AppHandle) -> Result<(), String> {
     // 先停止服务
     let state = app_handle.state::<AppState>();
@@ -1996,16 +2018,17 @@ pub fn run() {
                 recording_start_time: Arc::new(Mutex::new(None)),
                 is_processing_stop: Arc::new(AtomicBool::new(false)),
                 audio_mute_manager: Arc::new(Mutex::new(None)),
+                tray_icon: Arc::new(Mutex::new(None)),
             };
-            app.manage(app_state);
 
             // 创建托盘菜单
             let show_item = MenuItem::with_id(app, "show", "显示窗口", true, None::<&str>)?;
             let quit_item = MenuItem::with_id(app, "quit", "退出程序", true, None::<&str>)?;
             let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
 
-            // 创建系统托盘
-            let _tray = TrayIconBuilder::new()
+            // 始终创建系统托盘图标，但可按配置控制其是否在任务栏通知区域显示
+            let tray_icon_visible = AppConfig::load().map(|c| c.show_tray_icon).unwrap_or(true);
+            let tray = TrayIconBuilder::new()
                 .icon(app.default_window_icon().unwrap().clone())
                 .menu(&menu)
                 .tooltip("PushToTalk - AI 语音转写助手")
@@ -2032,6 +2055,10 @@ pub fn run() {
                     }
                 })
                 .build(app)?;
+            let _ = tray.set_visible(tray_icon_visible);
+            *app_state.tray_icon.lock().unwrap() = Some(tray);
+
+            app.manage(app_state);
 
             Ok(())
         })
@@ -2051,6 +2078,7 @@ pub fn run() {
             cancel_locked_recording,
             hide_to_tray,
             quit_app,
+            set_tray_icon_visible,
             show_overlay,
             hide_overlay,
             set_autostart,

--- a/src-tauri/src/text_inserter.rs
+++ b/src-tauri/src/text_inserter.rs
@@ -32,10 +32,15 @@ impl TextInserter {
 
         // 4. 模拟 Ctrl+V 粘贴
         self.enigo.key(Key::Control, Direction::Press)?;
-        thread::sleep(Duration::from_millis(10));
-        self.enigo.key(Key::Unicode('v'), Direction::Click)?;
-        thread::sleep(Duration::from_millis(10));
-        self.enigo.key(Key::Control, Direction::Release)?;
+        let result = (|| -> Result<()> {
+            thread::sleep(Duration::from_millis(10));
+            self.enigo.key(Key::Unicode('v'), Direction::Click)?;
+            thread::sleep(Duration::from_millis(10));
+            Ok(())
+        })();
+        // 最大努力保证 Ctrl 不会遗留为按下状态
+        let _ = self.enigo.key(Key::Control, Direction::Release);
+        result?;
 
         // 5. 等待粘贴完成
         thread::sleep(Duration::from_millis(100));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,6 +151,7 @@ interface AppConfig {
   smart_command_config: SmartCommandConfig;
   assistant_config: AssistantConfig;      // 新增：AI 助手配置
   close_action: "close" | "minimize" | null;
+  show_tray_icon: boolean;               // 是否显示系统托盘图标
   hotkey_config: HotkeyConfig;            // 保留用于迁移
   dual_hotkey_config: DualHotkeyConfig;   // 新增：双热键配置
   enable_mute_other_apps: boolean;        // 录音时静音其他应用
@@ -369,6 +370,7 @@ function App() {
   const [enableAutostart, setEnableAutostart] = useState(false);
   const [enableMuteOtherApps, setEnableMuteOtherApps] = useState(false);
   const [closeAction, setCloseAction] = useState<"close" | "minimize" | null>(null);
+  const [showTrayIcon, setShowTrayIcon] = useState(true);
   const [updateStatus, setUpdateStatus] = useState<"idle" | "checking" | "available" | "downloading" | "ready">("idle");
   const [updateInfo, setUpdateInfo] = useState<{ version: string; notes?: string } | null>(null);
   const [downloadProgress, setDownloadProgress] = useState(0);
@@ -531,6 +533,7 @@ function App() {
             assistantConfig,
             asrConfig,
             dualHotkeyConfig: newDualHotkeyConfig,
+            showTrayIcon,
             enableMuteOtherApps
           }).then(() => {
             const modeName = recordingMode === 'dictation' ? '听写' : recordingMode === 'release' ? '松手' : 'AI助手';
@@ -643,6 +646,9 @@ function App() {
       if (config.close_action) {
         setCloseAction(config.close_action);
       }
+
+      // 加载托盘图标显示配置（默认显示）
+      setShowTrayIcon(config.show_tray_icon ?? true);
 
       // 加载开机自启动状态
       try {
@@ -890,6 +896,7 @@ function App() {
         assistantConfig,
         asrConfig,
         dualHotkeyConfig,
+        showTrayIcon,
         enableMuteOtherApps,
         dictionary: validDictionary
       });
@@ -1057,6 +1064,7 @@ function App() {
           asrConfig,
           closeAction,
           dualHotkeyConfig,
+          showTrayIcon,
           enableMuteOtherApps,
           dictionary
         });
@@ -1107,6 +1115,7 @@ function App() {
           asrConfig,
           closeAction: action,
           dualHotkeyConfig,
+          showTrayIcon,
         });
       } catch (err) {
         console.error("保存关闭配置失败:", err);
@@ -2696,7 +2705,8 @@ function App() {
                               smartCommandConfig,
                               assistantConfig,
                               asrConfig,
-                              dualHotkeyConfig: newConfig
+                              dualHotkeyConfig: newConfig,
+                              showTrayIcon,
                             });
                           }}
                           disabled={status !== 'idle'}
@@ -2900,6 +2910,59 @@ function App() {
                       <span
                         className="absolute top-0.5 w-5 h-5 bg-white rounded-full shadow-sm transition-all duration-300"
                         style={{ left: enableAutostart ? 'calc(100% - 1.25rem - 2px)' : '2px' }}
+                      />
+                    </button>
+                  </div>
+
+                  {/* 系统托盘图标 */}
+                  <div className="flex items-center justify-between p-3.5 hover:bg-slate-100/50 transition-colors">
+                    <div className="flex items-center gap-3">
+                      <div className={`p-1.5 rounded-lg transition-colors ${
+                        showTrayIcon ? 'bg-blue-100 text-blue-600' : 'bg-slate-200 text-slate-500'
+                      }`}>
+                        <Minus size={16} />
+                      </div>
+                      <div>
+                        <div className="text-sm font-medium text-slate-700">显示系统托盘图标</div>
+                        <div className="text-[11px] text-slate-400 leading-tight">
+                          {showTrayIcon ? '显示在任务栏通知区域' : '已隐藏（仍在后台运行）'}
+                        </div>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => {
+                        const next = !showTrayIcon;
+                        setShowTrayIcon(next);
+                        // 立即生效（Windows 任务栏通知区域）
+                        invoke("set_tray_icon_visible", { visible: next }).catch((err) => {
+                          console.error("设置托盘图标显示状态失败:", err);
+                        });
+                        // 同步保存到配置，避免重启后回退
+                        invoke("save_config", {
+                          apiKey,
+                          fallbackApiKey,
+                          useRealtime,
+                          enablePostProcess,
+                          llmConfig,
+                          smartCommandConfig,
+                          assistantConfig,
+                          asrConfig,
+                          closeAction,
+                          dualHotkeyConfig,
+                          showTrayIcon: next,
+                          enableMuteOtherApps,
+                          dictionary,
+                        }).catch((err) => {
+                          console.error("保存托盘图标配置失败:", err);
+                        });
+                      }}
+                      className={`relative w-12 h-6 rounded-full transition-all duration-300 ${
+                        showTrayIcon ? 'bg-blue-500' : 'bg-slate-300'
+                      } cursor-pointer hover:opacity-90`}
+                    >
+                      <span
+                        className="absolute top-0.5 w-5 h-5 bg-white rounded-full shadow-sm transition-all duration-300"
+                        style={{ left: showTrayIcon ? 'calc(100% - 1.25rem - 2px)' : '2px' }}
                       />
                     </button>
                   </div>


### PR DESCRIPTION
## Bug 原因
- 偶尔会出现 Ctrl 像被按住（比如浏览器滚轮变成缩放）。

## 功能需求
- 添加可隐藏任务栏托盘图标的功能，让使用更无感。

## 修改内容
- Windows 热键监听：改为使用 `GetAsyncKeyState` 轮询物理按键（10ms），并采用严格匹配（目标组合按下且不允许额外修饰键），绕开 Hook 漏事件导致的 “Ghost Key”。
- Ctrl 问题：在模拟 `Ctrl+C / Ctrl+V` 的流程中，无论成功或异常返回都 best-effort 发送 `Ctrl Release`，避免系统层面残留 Ctrl 状态。
- 托盘图标：新增 `show_tray_icon` 配置 + `set_tray_icon_visible(visible: bool)` 命令 + 前端设置开关，支持即时生效并持久化。
